### PR TITLE
Removed hard coded slash that cause problem on Windows to start HQ Live Server

### DIFF
--- a/project-resolver.js
+++ b/project-resolver.js
@@ -1,11 +1,12 @@
 const { window } = require('vscode');
+const path = require('path');
 
 exports.getProject = workspaceFolders => {
   // TODO: get file name from images and other non text documents
   const activeFileName = window.activeTextEditor && window.activeTextEditor.document.fileName;
 
   if (activeFileName) {
-    const activeProject = workspaceFolders.find(project => activeFileName.startsWith(`${project.uri.fsPath}/`));
+    const activeProject = workspaceFolders.find(project => activeFileName.startsWith(`${project.uri.fsPath}${path.sep}`));
     if (!activeProject) {
       window.showErrorMessage(`Could not start HQ Live Server:
         Selected file ${activeFileName} does not belong to any projects`);


### PR DESCRIPTION
### What kind of change does this PR introduce?
- [X] Bugfix for https://github.com/hqjs/vscode-hq-live-server/issues/3
- [ ] Feature
- [ ] Other

### Summary
When `HQ Live Server` spins up on Windows `back slash` was not correctly resolved.
This fix brings support for both platforms `Windows` and `Unix`.
